### PR TITLE
Added 'trim' to classes list names for config

### DIFF
--- a/generate-config.php
+++ b/generate-config.php
@@ -18,7 +18,7 @@ file_put_contents(
       'rootNamespace' => $rootNamespace,
       'destDirectory' => $outputDocsPath,
       'format' => 'github',
-      'classes' => file($classesListFile),
+      'classes' => array_map('trim', file($classesListFile)),
     ],  
     true
    ) . ';'


### PR DESCRIPTION
I think this will fix such generated config files (extra line is not a correct one):
```php
return (object)array (
  'rootNamespace' => 'Imponeer\\Contracts\\Smarty\\',
  'destDirectory' => '/home/runner/work/_temp/new-wiki-89d52d29ae6ac19a5fa5d6fa5fb9a04b9e6f4b64-2609832018-1',
  'format' => 'github',
  'classes' => 
  array (
    0 => 'Imponeer\\Contracts\\Smarty\\Extension\\SmartyBlockInterface
',
    1 => 'Imponeer\\Contracts\\Smarty\\Extension\\SmartyCompilerInterface
',
    2 => 'Imponeer\\Contracts\\Smarty\\Extension\\SmartyExtensionInterface
',
    3 => 'Imponeer\\Contracts\\Smarty\\Extension\\SmartyFunctionInterface
',
    4 => 'Imponeer\\Contracts\\Smarty\\Extension\\SmartyModifierInterface
',
    5 => 'Imponeer\\Contracts\\Smarty\\Extension\\SmartyResourceInterface
',
    6 => 'Imponeer\\Contracts\\Smarty\\Filter\\SmartyFilterInterface
',
    7 => 'Imponeer\\Contracts\\Smarty\\Filter\\SmartyOutputFilterInterface
',
    8 => 'Imponeer\\Contracts\\Smarty\\Filter\\SmartyPostFilterInterface
',
    9 => 'Imponeer\\Contracts\\Smarty\\Filter\\SmartyPreFilterInterface',
  ),
);
```