### PR TITLE
docs: remove outdated interactive tutorial reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ This action supports such arguments (used in `with` keyword):
 
 ## How to contribute? 
 
-If you want to add some functionality or fix bugs, you can fork, change and create pull request. If you not sure how this works, try [interactive GitHub tutorial](https://skills.github.com).
+If you want to add some functionality or fix bugs, you can fork the repository, make changes, and create a pull request.
 
 If you found any bug or have some questions, use [issues tab](https://github.com/impresscms-dev/generate-phpdocs-with-clean-phpdoc-md-action/issues) and write there your questions.


### PR DESCRIPTION
## Summary
- remove obsolete interactive GitHub tutorial reference from README contribution section
- keep contribution guidance focused on forking and opening pull requests

## Testing
- not applicable (documentation-only change)